### PR TITLE
Implement secure session-based Instagram API proxy

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -21,7 +21,7 @@ module.exports = {
     {
       name: "@electron-forge/maker-squirrel",
       config: {
-        iconUrl: "https://robolike.com/favicon.ico",
+        iconUrl: "https://www.robolike.com/favicon.ico",
         setupIcon: "./icons/icon.ico",
       },
     },

--- a/src/config.js
+++ b/src/config.js
@@ -6,8 +6,8 @@
 require('dotenv').config();
 
 const config = {
-  baseUrl: process.env.BASE_URL || "https://robolike.com",
-  
+  baseUrl: process.env.BASE_URL || "https://www.robolike.com",
+
   // API endpoints
   api: {
     auth: {
@@ -15,7 +15,7 @@ const config = {
     },
     metrics: '/api/metrics'
   },
-  
+
   // App settings
   app: {
     protocol: 'robolike',

--- a/src/preload.js
+++ b/src/preload.js
@@ -5,6 +5,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
    getBaseUrl: () => ipcRenderer.invoke('config:getBaseUrl'),
    getConfig: () => ipcRenderer.invoke('config:getConfig'),
    
+   // Auth methods
+   auth: {
+     getAccessToken: () => ipcRenderer.invoke('auth:getAccessToken')
+   },
+   
+   // Instagram API methods
+   instagram: {
+     getRecentMedia: (hashtag) => ipcRenderer.invoke('instagram:getRecentMedia', hashtag)
+   },
+   
    // Analytics methods
    analytics: {
      setAccessToken: (token) => ipcRenderer.invoke('analytics:setAccessToken', token),


### PR DESCRIPTION
- Replace access token passing with IPC-based API proxy
- Add instagram.getRecentMedia IPC handler using session cookies
- Remove access token extraction from URL search params
- Securely store access token in main process when received
- Improve error handling for API requests with proper analytics tracking
- Update base URL to www.robolike.com in config and forge files