### PR TITLE
Fix macOS build signing and update GitHub Actions workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Apple Code Signing (optional for local development)
+# APPLE_SIGN_IDENTITY=Developer ID Application: Your Name (TEAMID)
+# APPLE_ID=your.email@example.com
+# APPLE_PASSWORD=your-app-specific-password
+# APPLE_TEAM_ID=YOUR_TEAM_ID
+
+# Base URL for the application
+BASE_URL=https://www.robolike.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,31 @@ jobs:
     - name: Install Dependencies
       run: npm install
     
-    - name: Build Application
+    - name: Setup Apple Certificate (macOS only)
+      if: matrix.os == 'macos-latest'
       run: |
-        npm run make
+        # Create keychain
+        security create-keychain -p "${{ secrets.KEYCHAIN_PASSWORD || 'temp_password' }}" build.keychain
+        security default-keychain -s build.keychain
+        security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD || 'temp_password' }}" build.keychain
+        security set-keychain-settings -t 3600 -u build.keychain
+        
+        # Import certificate if available
+        if [ ! -z "${{ secrets.APPLE_CERTIFICATE }}" ]; then
+          echo "${{ secrets.APPLE_CERTIFICATE }}" | base64 --decode > certificate.p12
+          security import certificate.p12 -k build.keychain -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.KEYCHAIN_PASSWORD || 'temp_password' }}" build.keychain
+        fi
+    
+    - name: Build Application
+      run: npm run make
+      env:
+        CI: true
+        BASE_URL: ${{ secrets.BASE_URL || 'https://www.robolike.com' }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        APPLE_SIGN_IDENTITY: ${{ secrets.APPLE_SIGN_IDENTITY }}
     
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v4

--- a/entitlements.plist
+++ b/entitlements.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- Required for Electron apps -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    
+    <!-- Required for network requests -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+  </dict>
+</plist>

--- a/forge.config.js
+++ b/forge.config.js
@@ -7,14 +7,22 @@ module.exports = {
   packagerConfig: {
     asar: true,
     icon: "./icons/icon", // Base name, platform extensions added automatically
-    osxSign: {
-      identity: process.env.APPLE_SIGN_IDENTITY,
-    },
-    osxNotarize: {
-      appleId: process.env.APPLE_ID,
-      appleIdPassword: process.env.APPLE_PASSWORD,
-      teamId: process.env.APPLE_TEAM_ID,
-    },
+    // Enable signing in CI or when certificate is available
+    ...(process.env.CI && process.env.APPLE_SIGN_IDENTITY ? {
+      osxSign: {
+        identity: process.env.APPLE_SIGN_IDENTITY,
+        'hardened-runtime': true,
+        'gatekeeper-assess': false,
+      },
+      osxNotarize: {
+        appleId: process.env.APPLE_ID,
+        appleIdPassword: process.env.APPLE_PASSWORD,
+        teamId: process.env.APPLE_TEAM_ID,
+      },
+    } : {
+      osxSign: false,
+      osxNotarize: false,
+    }),
   },
   rebuildConfig: {},
   makers: [


### PR DESCRIPTION
- Add conditional code signing for CI vs local development
- Configure GitHub Actions to use Apple signing secrets
- Add minimal entitlements.plist for Electron requirements only
- Create .env.example template for required environment variables
- Enable signing in CI when certificates are available